### PR TITLE
CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.0)
+project(natron-plugins VERSION 20210310)
+include(GNUInstallDirs)
+install(DIRECTORY
+    BL Channel Color Draw Filter GLSL Keyer Merge mS Relight SB Time Transform Utility Views V_Tools
+    DESTINATION
+    ${CMAKE_INSTALL_DATAROOTDIR}/Natron/Plugins/PyPlugs
+)
+install(FILES
+    Licenses/GPL-2.0
+    Licenses/CC-BY-2.0
+    README.md
+    DESTINATION
+    ${CMAKE_INSTALL_DOCDIR}-${PROJECT_VERSION}
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ include(GNUInstallDirs)
 install(DIRECTORY
     BL Channel Color Draw Filter GLSL Keyer Merge mS Relight SB Time Transform Utility Views V_Tools
     DESTINATION
-    ${CMAKE_INSTALL_DATAROOTDIR}/Natron/Plugins/PyPlugs
+    ${CMAKE_INSTALL_DATAROOTDIR}/Natron/Plugins
 )
 install(FILES
     Licenses/GPL-2.0


### PR DESCRIPTION
Make it easy to install and package the plugins.

```
mkdir build && cd build
```
```
cmake -DCMAKE_INSTALL_PREFIX=/usr .. && sudo make install
```
```
cmake -DCMAKE_INSTALL_PREFIX=/usr .. && make DESTDIR=`pwd`/pkg install
```
etc ...

Should also work on macOS/Windows (not tested), just add ``-DCMAKE_INSTALL_DATAROOTDIR=<PATH>`` where PATH is ``/Library/Application Support`` or ``C:\Program Files\Common Files``. Docs are installed in ``CMAKE_INSTALL_DATAROOTDIR/doc``, you can override this with ``-DCMAKE_INSTALL_DOCDIR=<PATH>``.